### PR TITLE
Vinculando as imagens da home ao produto

### DIFF
--- a/lib/models/gerenciador-produtos.dart
+++ b/lib/models/gerenciador-produtos.dart
@@ -39,4 +39,12 @@ class GerenciadorProduto extends ChangeNotifier{
     todosProdutos = snapshotProducts.docs.map((e) => Produto.fromDocument(e)).toList();
     notifyListeners();
   }
+
+  Produto? encontrarProdutoPorId (String id){
+    try{
+      return todosProdutos.firstWhere((p) => p.id == id);
+    }catch(e){
+      return null;
+    }
+  }
 }

--- a/lib/models/item-sessao.dart
+++ b/lib/models/item-sessao.dart
@@ -1,9 +1,11 @@
 class ItemSessao{
 
   String? image;
+  String? product;
 
   ItemSessao.fromMap(Map<String,dynamic>map){
     image = map["image"] as String;
+    product = map["product"] as String;
   }
 
 }

--- a/lib/telas/home/components/item-tile.dart
+++ b/lib/telas/home/components/item-tile.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:loja_virtual_completa/models/gerenciador-produtos.dart';
+import 'package:loja_virtual_completa/models/item-sessao.dart';
+import 'package:loja_virtual_completa/models/produto.dart';
+import 'package:provider/provider.dart';
+import 'package:transparent_image/transparent_image.dart';
+
+class ItemTile extends StatelessWidget {
+  final ItemSessao itemSessao;
+  const ItemTile({Key? key, required this.itemSessao}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: FadeInImage.memoryNetwork(
+          placeholder: kTransparentImage,
+          image: itemSessao.image!,
+          fit: BoxFit.cover,
+        )
+      ),
+      onTap: (){
+        if(itemSessao.product != null){
+          Produto? product = context.read<GerenciadorProduto>()
+              .encontrarProdutoPorId(itemSessao.product!);
+          if(product !=null){
+            Navigator.of(context).pushNamed("/detalhe-produto",arguments: product);
+          }
+        }
+      },
+    );
+  }
+}

--- a/lib/telas/home/components/sessao-list.dart
+++ b/lib/telas/home/components/sessao-list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:loja_virtual_completa/models/sessao.dart';
 import 'package:loja_virtual_completa/telas/home/components/header-sessao.dart';
+import 'package:loja_virtual_completa/telas/home/components/item-tile.dart';
 
 class SessaoLista extends StatelessWidget {
 
@@ -22,12 +23,8 @@ class SessaoLista extends StatelessWidget {
               itemCount: sessao.items!.length,
               separatorBuilder: (_,__)=> const SizedBox(width: 4,),
               itemBuilder: (context,index){
-                return AspectRatio(
-                  child: Image.network(
-                      sessao.items![index].image!,
-                      fit: BoxFit.cover,
-                  ),
-                  aspectRatio: 1,
+                return ItemTile(
+                  itemSessao: sessao.items![index],
                 );
               },
             ),

--- a/lib/telas/home/components/sessao-staggered.dart
+++ b/lib/telas/home/components/sessao-staggered.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:loja_virtual_completa/models/sessao.dart';
 import 'package:loja_virtual_completa/telas/home/components/header-sessao.dart';
+import 'package:loja_virtual_completa/telas/home/components/item-tile.dart';
 
 class SessaoStaggered extends StatelessWidget {
   final Sessao sessao;
@@ -21,9 +22,8 @@ class SessaoStaggered extends StatelessWidget {
             padding: EdgeInsets.zero,
             itemCount: sessao.items!.length,
             itemBuilder: (context,index){
-              return Image.network(
-                sessao.items![index].image!,
-                fit: BoxFit.cover,
+              return ItemTile(
+                itemSessao:sessao.items![index]
               );
             },
             staggeredTileBuilder: (index)=> StaggeredTile.count(2,index.isEven ? 2 : 1),

--- a/lib/telas/home/home-screen.dart
+++ b/lib/telas/home/home-screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:loja_virtual_completa/componentes-gerais/custom-drawer-header.dart';
+import 'package:loja_virtual_completa/componentes-gerais/drawer-customizado.dart';
 import 'package:loja_virtual_completa/models/gerenciador-home.dart';
 import 'package:loja_virtual_completa/telas/home/components/sessao-list.dart';
 import 'package:loja_virtual_completa/telas/home/components/sessao-staggered.dart';
@@ -11,7 +12,7 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      drawer: CustomDrawerHeader(),
+      drawer: DrawerCustomizado(),
       body: Stack(
         children: [
           Container(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -317,6 +317,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  transparent_image:
+    dependency: "direct main"
+    description:
+      name: transparent_image
+      sha256: e8991d955a2094e197ca24c645efec2faf4285772a4746126ca12875e54ca02f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   provider: ^6.0.5
   banner_carousel: ^1.2.1
   flutter_staggered_grid_view: ^0.4.0
-
+  transparent_image: ^2.0.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Criado componente para exibição das imagens da home.
Criação de um campo a mais na sessao de Home do firebase para receber o id do produto.
Vinculo entre os produtos e o que esta sendo exibido na home.
Utilização do package:transparent_image: ^2.0.1 para suavização da exibição das imagens na tela.
Correção do Drawer.
Navegação de tela após o click em alguma imagem que tenha a referencia do produto.